### PR TITLE
feat: exclude snaps UI

### DIFF
--- a/collector/score.py
+++ b/collector/score.py
@@ -49,9 +49,7 @@ def calculate_media_score(snap: Snap):
 def calculate_metadata_score(snap: Snap):
     """Calculate the metadata quality score for a snap."""
     # only count non empty links
-    num_of_links = min(
-        5, sum(1 for link in snap.links.values() if link)
-    )  # max 5 links
+    num_of_links = min(5, sum(1 for link in snap.links.values() if link))  # max 5 links
     set_license = snap.license != "unset"
     media_quality = calculate_media_score(snap)
     links_quality = (set_license + num_of_links) / 6
@@ -67,24 +65,14 @@ def calculate_dev_score(snap: Snap):
     return score
 
 
-def calculate_popularity_score(
-    active_devices_normalized, metadata_score, dev_score
-):
+def calculate_popularity_score(active_devices_normalized, metadata_score, dev_score):
     """Calculate the popularity score for a snap."""
-    return (
-        active_devices_normalized * 0.7
-        + metadata_score * 0.1
-        + dev_score * 0.2
-    )
+    return active_devices_normalized * 0.7 + metadata_score * 0.1 + dev_score * 0.2
 
 
-def calculate_recency_score(
-    last_updated_normalized, metadata_score, dev_score
-):
+def calculate_recency_score(last_updated_normalized, metadata_score, dev_score):
     """Calculate the recency score for a snap."""
-    return (
-        last_updated_normalized * 0.5 + metadata_score * 0.3 + dev_score * 0.2
-    )
+    return last_updated_normalized * 0.5 + metadata_score * 0.3 + dev_score * 0.2
 
 
 def calculate_trending_score(

--- a/snaprecommend/dashboard.py
+++ b/snaprecommend/dashboard.py
@@ -1,6 +1,10 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request, redirect, url_for
 from snaprecommend.sso import login_required
-from snaprecommend.logic import get_category_top_snaps
+from snaprecommend.logic import (
+    get_category_top_snaps,
+    exclude_snap_from_category,
+    get_all_categories,
+)
 
 dashboard_blueprint = Blueprint("dashboard", __name__)
 
@@ -21,3 +25,11 @@ def dashboard():
     }
 
     return render_template("dashboard.html", **context)
+@dashboard_blueprint.route("/exclude_snap", methods=["POST"])
+@login_required
+def exclude_snap():
+    snap_id = request.form.get("snap_id")
+    category = request.form.get("category")
+    if snap_id and category:
+        exclude_snap_from_category(category, snap_id)
+    return redirect(url_for("dashboard.dashboard"))

--- a/snaprecommend/dashboard.py
+++ b/snaprecommend/dashboard.py
@@ -3,7 +3,9 @@ from snaprecommend.sso import login_required
 from snaprecommend.logic import (
     get_category_top_snaps,
     exclude_snap_from_category,
+    include_snap_in_category,
     get_all_categories,
+    get_category_excluded_snaps,
 )
 
 dashboard_blueprint = Blueprint("dashboard", __name__)
@@ -25,6 +27,28 @@ def dashboard():
     }
 
     return render_template("dashboard.html", **context)
+
+
+@dashboard_blueprint.route("/excluded_snaps")
+@login_required
+def excluded_snaps():
+
+    excluded_snaps = []
+
+    for category in get_all_categories():
+        excluded_snaps.append(
+            {
+                "category": category,
+                "snaps": get_category_excluded_snaps(category.id),
+            }
+        )
+
+    context = {
+        "excluded_snaps": excluded_snaps,
+    }
+    return render_template("excluded_snaps.html", **context)
+
+
 @dashboard_blueprint.route("/exclude_snap", methods=["POST"])
 @login_required
 def exclude_snap():
@@ -33,3 +57,13 @@ def exclude_snap():
     if snap_id and category:
         exclude_snap_from_category(category, snap_id)
     return redirect(url_for("dashboard.dashboard"))
+
+
+@dashboard_blueprint.route("/include_snap", methods=["POST"])
+@login_required
+def include_snap():
+    snap_id = request.form.get("snap_id")
+    category = request.form.get("category")
+    if snap_id and category:
+        include_snap_in_category(category, snap_id)
+    return redirect(request.referrer)

--- a/snaprecommend/logic.py
+++ b/snaprecommend/logic.py
@@ -20,3 +20,41 @@ def get_category_top_snaps(category: str, limit: int = 50) -> list[Snap]:
     ).all()
 
     return snaps
+
+def exclude_snap_from_category(category: str, snap_id: str):
+    """
+    Excludes a snap from a given category.
+    """
+
+    snap_score = (
+        db.session.query(SnapRecommendationScore)
+        .filter_by(snap_id=snap_id, category=category)
+        .first()
+    )
+
+    if snap_score:
+        snap_score.exclude = True
+        db.session.commit()
+        return True
+
+    return False
+
+
+def include_snap_in_category(category: str, snap_id: str):
+    """
+    Includes a snap in a given category.
+    """
+
+    snap_score = (
+        db.session.query(SnapRecommendationScore)
+        .filter_by(snap_id=snap_id, category=category)
+        .first()
+    )
+
+    if snap_score:
+        snap_score.exclude = False
+        db.session.commit()
+        return True
+
+    return False
+

--- a/snaprecommend/templates/dashboard.html
+++ b/snaprecommend/templates/dashboard.html
@@ -14,14 +14,16 @@
                 <div class="col-4">
                     <h5>Most popular</h5>
                     <ul class="p-list" style="max-height: 650px; overflow: scroll;">
+                        {% set category= 'popular' %}
                         {% for snap in popular_snaps %}
-                            {% include "partials/snap_card.html" %}
+                            {% include "partials/snap_card.html"  %}
                         {% endfor %}
                     </ul>
                 </div>
                 <div class="col-4">
                     <h5>Recently updated</h5>
                     <ul class="p-list" style="max-height: 650px; overflow: scroll;">
+                        {% set category= 'recent' %}
                         {% for snap in recent_snaps %}
                             {% include "partials/snap_card.html" %}
                         {% endfor %}
@@ -30,6 +32,7 @@
                 <div class="col-4">
                     <h5>Trending</h5>
                     <ul class="p-list" style="max-height: 650px; overflow: scroll;">
+                        {% set category= 'trending' %}
                         {% for snap in trending_snaps %}
                             {% include "partials/snap_card.html" %}
                         {% endfor %}

--- a/snaprecommend/templates/excluded_snaps.html
+++ b/snaprecommend/templates/excluded_snaps.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %} {% block meta_title %}Excluded Snaps{% endblock %}
+{% block page_content %}
+<div class="p-panel">
+  <div class="p-panel__header">
+    <h4 class="p-panel__title">Excluded Snaps</h4>
+  </div>
+  <div class="p-panel__content">
+    <div class="u-fixed-width">
+      <h4>Excluded snaps</h4>
+      <ul class="p-list" style="max-height: 650px; overflow: scroll">
+        {% for excluded_group in excluded_snaps %}
+            <h5>{{ excluded_group.category.name }}</h5>
+            {% set category = excluded_group.category.id %} 
+            {% set excluded = True %}
+                {% for snap in excluded_group.snaps %} 
+                    {% include "partials/snap_card.html" %} 
+                {% endfor %}
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/snaprecommend/templates/layout.html
+++ b/snaprecommend/templates/layout.html
@@ -1,69 +1,92 @@
-{% extends "base.html" %}
-
-{% block title %}Dashboard{% endblock %}
-{% block meta_title %}Dashboard{% endblock %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %}Dashboard{% endblock %} {% block
+meta_title %}Dashboard{% endblock %} {% block content %}
 <style>
-.logo-text {
-  color: #fff;
-  left:15px;
-  top: 10px;
-  position: relative;
-}
+  .logo-text {
+    color: #fff;
+    left: 15px;
+    top: 10px;
+    position: relative;
+  }
 </style>
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="p-panel is-dark">
       <div class="p-panel__header">
         <a class="p-panel__logo" href="#">
-      <img
-        src="https://assets.ubuntu.com/v1/dae35907-Snapcraft%20tag.svg"
-        alt="Snapcraft"
-        style="height: 50px"
-      />
-      <div class="logo-text is-fading-when-collapsed">
-            <h4>
-            Snap recommendations
-            </h4>
-      </div>
+          <img
+            src="https://assets.ubuntu.com/v1/dae35907-Snapcraft%20tag.svg"
+            alt="Snapcraft"
+            style="height: 50px"
+          />
+          <div class="logo-text is-fading-when-collapsed">
+            <h4>Snap recommendations</h4>
+          </div>
         </a>
       </div>
-
     </div>
   </div>
 
-    <header class="l-navigation is-collapsed">
+  <header class="l-navigation is-collapsed">
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
         <div class="p-panel__header is-sticky">
           <div class="p-panel__logo">
-      <img
-        src="https://assets.ubuntu.com/v1/dae35907-Snapcraft%20tag.svg"
-        alt="Snapcraft"
-        class="p-panel__logo-image"
-        style="height: 50px"
-      />
-      <div class="logo-text  is-fading-when-collapsed">
-              <h5>
-        Snap recommendations
-              </h5>
-      </div>
+            <img
+              src="https://assets.ubuntu.com/v1/dae35907-Snapcraft%20tag.svg"
+              alt="Snapcraft"
+              class="p-panel__logo-image"
+              style="height: 50px"
+            />
+            <div class="logo-text is-fading-when-collapsed">
+              <h5>Snap recommendations</h5>
+            </div>
           </div>
           <div class="p-panel__controls u-hide--large">
-            <button class="p-button--base is-dark has-icon u-no-margin u-hide--medium js-menu-close"><i class="is-light p-icon--close"></i></button>
-            <button class="p-button--base is-dark has-icon u-no-margin u-hide--small js-menu-pin"><i class="is-light p-icon--pin"></i></button>
+            <button
+              class="p-button--base is-dark has-icon u-no-margin u-hide--medium js-menu-close"
+            >
+              <i class="is-light p-icon--close"></i>
+            </button>
+            <button
+              class="p-button--base is-dark has-icon u-no-margin u-hide--small js-menu-pin"
+            >
+              <i class="is-light p-icon--pin"></i>
+            </button>
           </div>
         </div>
         <div class="p-panel__content">
-
-
-
           <div class="p-side-navigation--icons" id="drawer-icons">
             <nav aria-label="Main">
               <ul class="p-side-navigation__list">
                 <li class="p-side-navigation__item">
-                  <a class="p-side-navigation__link" aria-current="page" href="#"><i class="p-icon--information is-light p-side-navigation__icon"></i> <span class="p-side-navigation__label"><span class="p-side-navigation__label">Dashboard</span></span></a>
+                  <a
+                    class="p-side-navigation__link"
+                    aria-current="{% if request.path == '/dashboard/' %}page{% endif %}"
+                    href="/dashboard"
+                    ><i
+                      class="p-icon--information is-light p-side-navigation__icon"
+                    ></i>
+                    <span class="p-side-navigation__label"
+                      ><span class="p-side-navigation__label"
+                        >Dashboard</span
+                      ></span
+                    ></a
+                  >
+                </li>
+                <li class="p-side-navigation__item">
+                  <a
+                    class="p-side-navigation__link"
+                    aria-current="{% if request.path == '/dashboard/excluded_snaps' %}page{% endif %}"
+                    href="/dashboard/excluded_snaps"
+                    ><i
+                      class="p-icon--delete is-light p-side-navigation__icon"
+                    ></i>
+                    <span class="p-side-navigation__label"
+                      ><span class="p-side-navigation__label"
+                        >Excluded snaps</span
+                      ></span
+                    ></a
+                  >
                 </li>
               </ul>
             </nav>
@@ -73,9 +96,6 @@
     </div>
   </header>
 
-  <main class="l-main">
-        {% block page_content %}
-        {% endblock %}
-  </main>
+  <main class="l-main">{% block page_content %} {% endblock %}</main>
 </div>
 {% endblock %}

--- a/snaprecommend/templates/partials/snap_card.html
+++ b/snaprecommend/templates/partials/snap_card.html
@@ -1,9 +1,32 @@
 <li>
-    <div class="p-card">
-        <div style="display:flex; gap:12px;">
-            <img src="{{ snap.icon }}" alt="{{ snap.name }}" style="height:50px;" class="u-icon">
-            <h4><a href="https://snapcraft.io/{{ snap.name }}" target="_blank">{{ snap.name }}</a></h4>
-        </div>
-        <p class="card__content u-truncate">{{ snap.summary }}</p>
+  <div class="p-card">
+    <div style="display: flex; justify-content: space-between">
+      <div style="display: flex; gap: 12px">
+        <img
+          src="{{ snap.icon }}"
+          alt="{{ snap.name }}"
+          style="height: 50px"
+          class="u-icon"
+        />
+
+        <h4>
+          <a href="https://snapcraft.io/{{ snap.name }}" target="_blank"
+            >{{ snap.name }}</a
+          >
+        </h4>
+      </div>
+      <form
+        action="{{ url_for('dashboard.exclude_snap') }}"
+        method="post"
+        style="margin: 0"
+      >
+        <input type="hidden" name="snap_id" value="{{ snap.snap_id }}" />
+        <input type="hidden" name="category" value="{{ category }}" />
+        <button type="submit" class="p-button--negative has-icon">
+          <i class="p-icon--delete is-dark"></i><span>Exclude</span>
+        </button>
+      </form>
     </div>
+    <p class="card__content u-truncate">{{ snap.summary }}</p>
+  </div>
 </li>

--- a/snaprecommend/templates/partials/snap_card.html
+++ b/snaprecommend/templates/partials/snap_card.html
@@ -15,6 +15,19 @@
           >
         </h4>
       </div>
+      {% if excluded %}
+      <form
+        action="{{ url_for('dashboard.include_snap') }}"
+        method="post"
+        style="margin: 0"
+      >
+        <input type="hidden" name="snap_id" value="{{ snap.snap_id }}" />
+        <input type="hidden" name="category" value="{{ category }}" />
+        <button type="submit" class="p-button--positive has-icon">
+          <i class="p-icon--plus is-dark"></i><span>Include</span>
+        </button>
+      </form>
+      {% else %}
       <form
         action="{{ url_for('dashboard.exclude_snap') }}"
         method="post"
@@ -26,6 +39,7 @@
           <i class="p-icon--delete is-dark"></i><span>Exclude</span>
         </button>
       </form>
+      {% endif %}
     </div>
     <p class="card__content u-truncate">{{ snap.summary }}</p>
   </div>


### PR DESCRIPTION
# Done
- add new page for excluded snaps
- add button to exclude/include snaps
(yes, UI is super ugly, still a WIP but for now testing functionality is the priority)
# QA
- go to /dashboard
- exclude some snaps
- go to excluded snaps page
- include them back
- see them appear in dashboard