### PR TITLE
feat: explore page API

### DIFF
--- a/snaprecommend/api.py
+++ b/snaprecommend/api.py
@@ -107,6 +107,4 @@ def serialize_snap(snap: Snap) -> dict:
         "developer_validation": snap.developer_validation,
         "license": snap.license,
         "last_updated": snap.last_updated,
-        "active_devices": snap.active_devices,
-        "reaches_min_threshold": snap.reaches_min_threshold,
     }

--- a/snaprecommend/logic.py
+++ b/snaprecommend/logic.py
@@ -2,6 +2,7 @@ from snaprecommend.models import (
     Snap,
     SnapRecommendationScore,
     RecommendationCategory,
+    EditorialSlice,
     EditorialSliceSnap,
 )
 from snaprecommend import db

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -1,0 +1,24 @@
+from snaprecommend.models import Snap
+
+
+def mock_snap() -> Snap:
+    return Snap(
+        snap_id=1,
+        name="Snap1",
+        title="Mock Title 1",
+        version="1.0.0",
+        summary="This is a summary of Snap1.",
+        description="Detailed description of Snap1.",
+        icon="https://example.com/snap1/icon.png",
+        website="https://example.com/snap1",
+        contact="support@example.com",
+        publisher="Mock Publisher 1",
+        revision=42,
+        links=["https://example.com/snap1/docs"],
+        media=["https://example.com/snap1/media.png"],
+        developer_validation=True,
+        license="MIT",
+        last_updated="2024-02-17T12:00:00Z",
+        active_devices=1000,
+        reaches_min_threshold=True,
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from snaprecommend.api import (
     format_response,
 )
 from snaprecommend.models import Snap
+from tests.mock_data import mock_snap
 
 
 @pytest.fixture
@@ -47,15 +48,61 @@ def test_get_category_top_snaps(mock_query):
 
 
 def test_format_response():
-    mock_snaps = [
-        Snap(snap_id=1, name="Snap1"),
-        Snap(snap_id=2, name="Snap2"),
-    ]
+    snap1 = mock_snap()
+    snap2 = mock_snap()
+    snap2.snap_id = 2
+    snap2.title = "Mock Title 2"
+    snap2.name = "Snap2"
+    snap2.version = "2.1.0"
+    mock_snaps = [snap1, snap2]
     response = format_response(mock_snaps)
+    print(response)
 
     assert response == [
-        {"snap_id": 1, "name": "Snap1", "rank": 1},
-        {"snap_id": 2, "name": "Snap2", "rank": 2},
+        {
+            "snap_id": 1,
+            "rank": 1,
+            "details": {
+                "snap_id": 1,
+                "title": "Mock Title 1",
+                "name": "Snap1",
+                "version": "1.0.0",
+                "summary": "This is a summary of Snap1.",
+                "description": "Detailed description of Snap1.",
+                "icon": "https://example.com/snap1/icon.png",
+                "website": "https://example.com/snap1",
+                "contact": "support@example.com",
+                "publisher": "Mock Publisher 1",
+                "revision": 42,
+                "links": ["https://example.com/snap1/docs"],
+                "media": ["https://example.com/snap1/media.png"],
+                "developer_validation": True,
+                "license": "MIT",
+                "last_updated": "2024-02-17T12:00:00Z",
+            },
+        },
+        {
+            "snap_id": 2,
+            "rank": 2,
+            "details": {
+                "snap_id": 2,
+                "title": "Mock Title 2",
+                "name": "Snap2",
+                "version": "2.1.0",
+                "summary": "This is a summary of Snap1.",
+                "description": "Detailed description of Snap1.",
+                "icon": "https://example.com/snap1/icon.png",
+                "website": "https://example.com/snap1",
+                "contact": "support@example.com",
+                "publisher": "Mock Publisher 1",
+                "revision": 42,
+                "links": ["https://example.com/snap1/docs"],
+                "media": ["https://example.com/snap1/media.png"],
+                "developer_validation": True,
+                "license": "MIT",
+                "last_updated": "2024-02-17T12:00:00Z",
+            },
+        },
     ]
 
 
@@ -69,16 +116,35 @@ def test_category_endpoint(mock_get_category_top_snaps, mock_query, client):
     mock_query.filter_by.return_value.first.return_value = mock_category
 
     mock_snaps = [
-        Snap(snap_id=1, name="Snap1"),
-        Snap(snap_id=2, name="Snap2"),
+        mock_snap(),
     ]
     mock_get_category_top_snaps.return_value = mock_snaps
 
     response = client.get("/category/popular")
     assert response.status_code == 200
     assert response.json == [
-        {"snap_id": 1, "name": "Snap1", "rank": 1},
-        {"snap_id": 2, "name": "Snap2", "rank": 2},
+        {
+            "snap_id": 1,
+            "rank": 1,
+            "details": {
+                "snap_id": 1,
+                "title": "Mock Title 1",
+                "name": "Snap1",
+                "version": "1.0.0",
+                "summary": "This is a summary of Snap1.",
+                "description": "Detailed description of Snap1.",
+                "icon": "https://example.com/snap1/icon.png",
+                "website": "https://example.com/snap1",
+                "contact": "support@example.com",
+                "publisher": "Mock Publisher 1",
+                "revision": 42,
+                "links": ["https://example.com/snap1/docs"],
+                "media": ["https://example.com/snap1/media.png"],
+                "developer_validation": True,
+                "license": "MIT",
+                "last_updated": "2024-02-17T12:00:00Z",
+            },
+        },
     ]
     mock_query.filter_by.assert_called_once_with(id="popular")
     mock_get_category_top_snaps.assert_called_once_with("popular")


### PR DESCRIPTION
# Done 
- add API endpoints for explore page

# Q/A
Try the following and verify they send all required fields
- `/api/categories`
- `/api/category/<id>`
- `/api/slices`
- `/api/slice/<id>`