### PR TITLE
feat: trigger step from dashboard

### DIFF
--- a/snaprecommend/__init__.py
+++ b/snaprecommend/__init__.py
@@ -65,7 +65,7 @@ def scheduled_collector():
 
     with app.app_context():
         try:
-            collect_data(entire_pipeline=True)
+            collect_data()
         except Exception as e:
             app.logger.error(f"Error starting scheduled collector: {e}")
 

--- a/snaprecommend/logic.py
+++ b/snaprecommend/logic.py
@@ -184,7 +184,7 @@ def get_most_recent_pipeline_step_logs():
         }
 
         step_info = {
-            "id": step,
+            "id": step.value,
             "name": names.get(step, step),
             "success": None,
             "last_successful_run": None,

--- a/snaprecommend/templates/base.html
+++ b/snaprecommend/templates/base.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <!--
   This is a basic HTML file template to become the new homepage of the site.
   Currently it simply includes Vanilla styles and not much else.
@@ -7,23 +6,23 @@
   When you come to work on it in ernest, please remove this comment
   and replace index.html with this file.
 -->
-
 <html lang="en">
-
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-  <title>
-    {% block meta_title %}Home{% endblock %} | Snap recommendations service 
-  </title>
-  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.21.0.min.css" />
-</head>
-
-<body >
-  {% block body %}
-    {% block content %}{% endblock %}
-  {% endblock body %}
-</body>
-
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>
+      {% block meta_title %}Home{% endblock %}
+      | Snap recommendations service
+    </title>
+    <link rel="shortcut icon"
+          href="https://assets.ubuntu.com/v1/d4ca039f-favicon_16px.png">
+    <link rel="stylesheet"
+          href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.21.0.min.css" />
+  </head>
+  <body>
+    {% block body %}
+      {% block content %}{% endblock %}
+    {% endblock body %}
+  </body>
 </html>

--- a/snaprecommend/templates/settings.html
+++ b/snaprecommend/templates/settings.html
@@ -42,7 +42,7 @@
                   <td>{{ step.last_successful_run.strftime("%Y-%m-%d %H:%M:%S") if step.last_successful_run else "-" }}</td>
                   <td>{{ step.last_failed_run.strftime("%Y-%m-%d %H:%M:%S") if step.last_failed_run else "-" }}</td>
                   <td>
-                    <form action="{{ url_for('dashboard.run_pipeline_step', step_name=step.name) }}"
+                    <form action="{{ url_for('dashboard.run_pipeline_step', step_name=step.id) }}"
                           method="post">
                       <button type="submit" class="p-button--positive">Run now</button>
                     </form>


### PR DESCRIPTION
# Done
- You can trigger pipeline steps from the settings page

# Q/A
- go to `/dashboard/settings`
- click "Run now" on one of the steps (score and filter finish the fastest, the rest take a while)
- There is no way (for now) to tell when a step is in progress, so you refresh and wait until the last run time is updated. (I know, this sucks, working on "in_progress" status)