### PR TITLE
feat: make snap exclusion from recommendations global across categories

### DIFF
--- a/collector/score.py
+++ b/collector/score.py
@@ -125,7 +125,7 @@ def calculate_category_scores():
 
     session = db.session
 
-    filter_condition = Snap.reaches_min_threshold.is_(True)
+    filter_condition = Snap.reaches_min_threshold.is_(True) & Snap.excluded.is_(False)
 
     min_active_devices, max_active_devices = normalize_field(
         session, Snap.active_devices, filter_condition=filter_condition
@@ -349,7 +349,6 @@ def migrate_current_scores():
             "snap_id": score.snap_id,
             "category": score.category,
             "created_at": score.created_at,
-            "exclude": score.exclude,
             "score": score.score,
         }
         for score in scores

--- a/frontend/src/components/CategoryList/CategoryList.tsx
+++ b/frontend/src/components/CategoryList/CategoryList.tsx
@@ -20,8 +20,7 @@ export const CategoryList = ({ category, label }: { category: string, label: str
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({
-                "snap_id": snap.snap_id,
-                "category": category
+                "snap_id": snap.snap_id
             }),
         });
         await refetch();

--- a/frontend/src/pages/ExcludeSnaps.tsx
+++ b/frontend/src/pages/ExcludeSnaps.tsx
@@ -4,27 +4,18 @@ import type { Snap } from "../types/snap";
 import { AsyncBoundary } from "../components/AsyncBoundary/AsyncBoundary";
 import { useApi } from "../hooks/useApi";
 
-type ExcludedSnapResponse = Array<{
-    "category": {
-        name: string,
-        id: string,
-    },
-    "snaps": Snap[]
-}>
-
 export function ExcludeSnaps() {
-    const { error, loading, data, refetch } = useFetchData<ExcludedSnapResponse>('/api/excluded_snaps');
+    const { error, loading, data, refetch } = useFetchData<Snap[]>('/api/excluded_snaps');
     const { sendRequest, error: includeError } = useApi();
 
-    const includeSnap = async (snap: Snap, category: string) => {
+    const includeSnap = async (snap: Snap) => {
         await sendRequest("/api/include_snap", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({
-                "snap_id": snap.snap_id,
-                "category": category
+                "snap_id": snap.snap_id
             }),
         });
         await refetch();
@@ -39,21 +30,17 @@ export function ExcludeSnaps() {
                 <div className="u-fixed-width">
                     <AsyncBoundary label="Excluded snaps" loading={loading} error={includeError || error ? "An error occurred" : undefined}>
                         <ul className="p-list" style={{ maxHeight: "650px", overflow: "scroll" }}>
-                            {data?.map((info) => (
-                                <div key={info.category.id}>
-                                    <h5>{info.category.name}</h5>
-                                    {info.snaps.map(snap => <SnapCard
-                                        key={snap.snap_id}
-                                        snap={snap}
-                                        actionButton={
-                                            <button className="p-button--positive has-icon" onClick={() => includeSnap(snap, info.category.id)}>
-                                                <i className="p-icon--plus is-dark"></i>
-                                                <span>Include</span>
-                                            </button>
-                                        }
-                                    />)}
-                                </div>
-                            ))}
+                            <h5>Globally excluded (all categories)</h5>
+                            {data?.map(snap => <SnapCard
+                                key={snap.snap_id}
+                                snap={snap}
+                                actionButton={
+                                    <button className="p-button--positive has-icon" onClick={() => includeSnap(snap)}>
+                                        <i className="p-icon--plus is-dark"></i>
+                                        <span>Include</span>
+                                    </button>
+                                }
+                            />)}
                         </ul>
                     </AsyncBoundary>
                 </div>

--- a/migrations/versions/1ec204a4d8f2_add_global_snap_exclusion.py
+++ b/migrations/versions/1ec204a4d8f2_add_global_snap_exclusion.py
@@ -1,0 +1,28 @@
+"""add global snap exclusion
+
+Revision ID: 1ec204a4d8f2
+Revises: c1096f7c4215
+Create Date: 2026-03-11 11:40:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1ec204a4d8f2'
+down_revision = 'c1096f7c4215'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('snap', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('excluded', sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('snap', schema=None) as batch_op:
+        batch_op.drop_column('excluded')

--- a/migrations/versions/b2cb1a7be131_remove_score_exclude_columns.py
+++ b/migrations/versions/b2cb1a7be131_remove_score_exclude_columns.py
@@ -1,0 +1,36 @@
+"""remove score exclude columns
+
+Revision ID: b2cb1a7be131
+Revises: 1ec204a4d8f2
+Create Date: 2026-03-11 12:36:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2cb1a7be131'
+down_revision = '1ec204a4d8f2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('snap_recommendation_score', schema=None) as batch_op:
+        batch_op.drop_column('exclude')
+
+    with op.batch_alter_table('snap_recommendation_score_history', schema=None) as batch_op:
+        batch_op.drop_column('exclude')
+
+
+def downgrade():
+    with op.batch_alter_table('snap_recommendation_score_history', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('exclude', sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+
+    with op.batch_alter_table('snap_recommendation_score', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('exclude', sa.Boolean(), nullable=False, server_default=sa.false())
+        )

--- a/snaprecommend/api.py
+++ b/snaprecommend/api.py
@@ -11,11 +11,11 @@ from snaprecommend.logic import (
     get_slice_snaps,
     get_all_categories,
     get_all_slices,
-    get_category_excluded_snaps,
-    include_snap_in_category,
+    get_excluded_snaps,
+    include_snap as include_snap_globally,
     get_snap_by_name,
     get_most_recent_pipeline_step_logs,
-    exclude_snap_from_category,
+    exclude_snap as exclude_snap_globally,
 )
 from snaprecommend.auth.decorators import login_required
 from snaprecommend.editorials import (
@@ -117,16 +117,10 @@ def popular_snaps():
 @api_blueprint.route("/excluded_snaps")
 @login_required
 def excluded_snaps():
-    excluded_snaps = []
-    for category in get_all_categories():
-        snaps = get_category_excluded_snaps(category.id)
-        excluded_snaps.append(
-            {
-                "category": {"name": category.name, "id": category.id},
-                "snaps": [serialize_snap(snap) for snap in snaps],
-            }
-        )
-    return flask.jsonify(excluded_snaps), 200
+    globally_excluded_snaps = get_excluded_snaps()
+    return flask.jsonify(
+        [serialize_snap(snap) for snap in globally_excluded_snaps]
+    ), 200
 
 
 @api_blueprint.route("/include_snap", methods=["POST"])
@@ -134,9 +128,8 @@ def excluded_snaps():
 def include_snap():
     data = flask.request.get_json()
     snap_id = data.get("snap_id")
-    category = data.get("category")
-    if snap_id and category:
-        include_snap_in_category(category, snap_id)
+    if snap_id:
+        include_snap_globally(snap_id)
     return flask.jsonify({"status": "success"}), 200
 
 
@@ -312,9 +305,8 @@ def run_pipeline_step():
 def exclude_snap():
     data = flask.request.get_json()
     snap_id = data.get("snap_id")
-    category = data.get("category")
-    if snap_id and category:
-        exclude_snap_from_category(category, snap_id)
+    if snap_id:
+        exclude_snap_globally(snap_id)
     return flask.jsonify({"status": "success"}), 200
 
 

--- a/snaprecommend/logic.py
+++ b/snaprecommend/logic.py
@@ -27,8 +27,8 @@ def get_category_top_snaps(category: str, limit: int = 50) -> list[Snap]:
             Snap.snap_id == SnapRecommendationScore.snap_id,
         )
         .filter(Snap.reaches_min_threshold.is_(True))
+        .filter(Snap.excluded.is_(False))
         .filter(SnapRecommendationScore.category == category)
-        .filter(SnapRecommendationScore.exclude.is_(False))
         .order_by(SnapRecommendationScore.score.desc())
         .limit(limit)
     ).all()
@@ -36,41 +36,21 @@ def get_category_top_snaps(category: str, limit: int = 50) -> list[Snap]:
     return snaps
 
 
-def exclude_snap_from_category(category: str, snap_id: str):
-    """
-    Excludes a snap from a given category.
-    """
-
-    snap_score = (
-        db.session.query(SnapRecommendationScore)
-        .filter_by(snap_id=snap_id, category=category)
-        .first()
-    )
-
-    if snap_score:
-        snap_score.exclude = True
+def exclude_snap(snap_id: str):
+    snap = db.session.query(Snap).filter_by(snap_id=snap_id).first()
+    if snap:
+        snap.excluded = True
         db.session.commit()
         return True
-
     return False
 
 
-def include_snap_in_category(category: str, snap_id: str):
-    """
-    Includes a snap in a given category.
-    """
-
-    snap_score = (
-        db.session.query(SnapRecommendationScore)
-        .filter_by(snap_id=snap_id, category=category)
-        .first()
-    )
-
-    if snap_score:
-        snap_score.exclude = False
+def include_snap(snap_id: str):
+    snap = db.session.query(Snap).filter_by(snap_id=snap_id).first()
+    if snap:
+        snap.excluded = False
         db.session.commit()
         return True
-
     return False
 
 
@@ -84,23 +64,8 @@ def get_all_categories() -> list[RecommendationCategory]:
     return categories
 
 
-def get_category_excluded_snaps(category: str) -> list[Snap]:
-    """
-    Returns the excluded snaps for a given category.
-    """
-
-    snaps = (
-        db.session.query(Snap)
-        .join(
-            SnapRecommendationScore,
-            Snap.snap_id == SnapRecommendationScore.snap_id,
-        )
-        .filter(SnapRecommendationScore.category == category)
-        .filter(SnapRecommendationScore.exclude.is_(True))
-        .order_by(SnapRecommendationScore.score.desc())
-    ).all()
-
-    return snaps
+def get_excluded_snaps() -> list[Snap]:
+    return db.session.query(Snap).filter(Snap.excluded.is_(True)).all()
 
 
 def get_all_slices() -> list[EditorialSlice]:

--- a/snaprecommend/models.py
+++ b/snaprecommend/models.py
@@ -41,6 +41,7 @@ class Snap(db.Model):
     raw_rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     total_votes: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     reaches_min_threshold: Mapped[bool] = mapped_column(Boolean, default=False)
+    excluded: Mapped[bool] = mapped_column(Boolean, default=False)
 
 
 class RecommendationCategory(db.Model):
@@ -71,7 +72,6 @@ class SnapRecommendationScore(db.Model):
         primary_key=True,
     )
     score: Mapped[float] = mapped_column(Float)
-    exclude: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.now
     )
@@ -93,7 +93,6 @@ class SnapRecommendationScoreHistory(db.Model):
         primary_key=True,
     )
     score: Mapped[float] = mapped_column(Float)
-    exclude: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.now, primary_key=True
     )


### PR DESCRIPTION
## Done
- exclusion now is on the snap level rather than the category level
- context: old logic allowed for a snap to be present in multiple categories at once, however, this was reworked to prevent duplication across categories. The old exclusion logic operated under the old assumptions. Now, it doesn't make much sense to exclude a snap from one category only since the snap will only be in one category anyway.

## Q/A
- go to https://snap-recommendation-service-126.demos.haus/dashboard
- exclude snap, see it removed from the list 
- include it back from excluded snaps page, see it back in the category
