### PR TITLE
feat: collect snap categories and add featured_history table

### DIFF
--- a/collector/collect.py
+++ b/collector/collect.py
@@ -24,6 +24,7 @@ FIELDS = (
     "media",
     "developer_validation",
     "license",
+    "sections",
 )
 
 URL = f"http://api.snapcraft.io/api/v1/snaps/search?fields={','.join(FIELDS)}&scope=wide&confinement=strict,classic"
@@ -59,6 +60,7 @@ def parse_snap_from_response(snap: dict) -> dict:
         "license": snap["license"],
         "last_updated": datetime.datetime.fromisoformat(snap["last_updated"].replace("Z", "+00:00")),
         "date_published": datetime.datetime.fromisoformat(snap["date_published"].replace("Z", "+00:00")) if snap.get("date_published") else None,
+        "categories": snap.get("sections"),
     }
 
 
@@ -154,6 +156,7 @@ def bulk_upsert_snaps(session: Session, snaps: list):
                 "license": stmt.excluded.license,
                 "last_updated": stmt.excluded.last_updated,
                 "date_published": stmt.excluded.date_published,
+                "categories": stmt.excluded.categories,
                 # created_at is intentionally excluded to preserve the original value
             },
         )

--- a/migrations/versions/a1b2c3d4e5f6_add_categories_to_snap.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_categories_to_snap.py
@@ -1,0 +1,26 @@
+"""Add categories to snap
+
+Revision ID: a1b2c3d4e5f6
+Revises: b6616f20474f
+Create Date: 2026-07-02 12:02:15.765109
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'b6616f20474f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('snap', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('categories', sa.JSON(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('snap', schema=None) as batch_op:
+        batch_op.drop_column('categories')

--- a/migrations/versions/b2c3d4e5f6a7_create_featured_history.py
+++ b/migrations/versions/b2c3d4e5f6a7_create_featured_history.py
@@ -22,7 +22,7 @@ def upgrade():
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
         sa.Column("snap_id", sa.String(), nullable=False),
         sa.Column("featured_at", sa.DateTime(), nullable=False),
-        sa.Column("is_manual", sa.Boolean(), nullable=False),
+        sa.Column("is_manual", sa.Boolean(), nullable=False, server_default=sa.false()),
         sa.Column("selection_reason", sa.JSON(), nullable=True),
         sa.ForeignKeyConstraint(
             ["snap_id"], ["snap.snap_id"], ondelete="CASCADE"

--- a/migrations/versions/b2c3d4e5f6a7_create_featured_history.py
+++ b/migrations/versions/b2c3d4e5f6a7_create_featured_history.py
@@ -1,0 +1,44 @@
+"""Create featured_history table
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-02 12:05:20.355084
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6a7'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "featured_history",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("snap_id", sa.String(), nullable=False),
+        sa.Column("featured_at", sa.DateTime(), nullable=False),
+        sa.Column("is_manual", sa.Boolean(), nullable=False),
+        sa.Column("selection_reason", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["snap_id"], ["snap.snap_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_featured_history_snap_id_featured_at",
+        "featured_history",
+        ["snap_id", "featured_at"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_featured_history_snap_id_featured_at",
+        table_name="featured_history",
+    )
+    op.drop_table("featured_history")

--- a/snaprecommend/models.py
+++ b/snaprecommend/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     ForeignKey,
     JSON,
     Enum,
+    Index,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 import enum
@@ -43,6 +44,7 @@ class Snap(db.Model):
     reaches_min_threshold: Mapped[bool] = mapped_column(Boolean, default=False)
     excluded: Mapped[bool] = mapped_column(Boolean, default=False)
     date_published: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    categories: Mapped[Optional[JSON]] = mapped_column(JSON, nullable=True)
 
 
 class RecommendationCategory(db.Model):
@@ -96,6 +98,34 @@ class SnapRecommendationScoreHistory(db.Model):
     score: Mapped[float] = mapped_column(Float)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.now, primary_key=True
+    )
+
+
+class FeaturedHistory(db.Model):
+    """
+    One row each time a snap is added to the featured list.
+    """
+
+    __tablename__: str = "featured_history"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True
+    )
+    snap_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("snap.snap_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    featured_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    is_manual: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    selection_reason: Mapped[Optional[JSON]] = mapped_column(
+        JSON, nullable=True
+    )
+
+    __table_args__ = (
+        Index("ix_featured_history_snap_id_featured_at", "snap_id", "featured_at"),
     )
 
 

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -21,4 +21,5 @@ def mock_snap() -> Snap:
         last_updated="2024-02-17T12:00:00Z",
         active_devices=1000,
         reaches_min_threshold=True,
+        categories=[{"name": "development", "featured": False}],
     )

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -38,6 +38,7 @@ def sample_snap():
         "media": [{"type": "icon", "url": "https://example.com/icon.png"}],
         "developer_validation": True,
         "license": "MIT",
+        "sections": [{"name": "development", "featured": False}],
     }
 
 
@@ -61,7 +62,7 @@ def test_get_snap_page(mock_get):
     assert len(snaps) == 2
     assert has_next is True
     mock_get.assert_called_once_with(
-        "http://api.snapcraft.io/api/v1/snaps/search?fields=snap_id,package_name,last_updated,date_published,summary,description,title,version,publisher,revision,links,media,developer_validation,license&scope=wide&confinement=strict,classic&page=1"
+        "http://api.snapcraft.io/api/v1/snaps/search?fields=snap_id,package_name,last_updated,date_published,summary,description,title,version,publisher,revision,links,media,developer_validation,license,sections&scope=wide&confinement=strict,classic&page=1"
     )
 
 
@@ -133,6 +134,7 @@ def test_bulk_upsert_snaps(mock_insert, mock_session, sample_snap):
                     sample_snap["last_updated"]
                 ),
                 "date_published": None,
+                "categories": sample_snap["sections"],
             }
         ]
     )


### PR DESCRIPTION
- Snap.categories aded. Its a new nullable JSON column, populated from the search API's sections. Existing rows backfill via the collector's upsert on the next run (no data migration needed).
- Aded featured_history table: its a one row per featuring event
- Two Alembic migrations: updated collector mapping + tests.
https://warthogs.atlassian.net/browse/WD-37563